### PR TITLE
Bugfix/fix short namespace order

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    transform: {'^.+\\.ts?$': 'ts-jest'},
+    testEnvironment: 'node',
+    testRegex: '/tests/.*\\.(test|spec)?\\.(ts|tsx)$',
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+  };

--- a/package.json
+++ b/package.json
@@ -67,15 +67,19 @@
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "watch": "node_modules/.bin/tsc -w -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "package": "node_modules/.bin/vsce package"
+        "package": "node_modules/.bin/vsce package",
+        "test": "jest",
+        "coverage": "jest --coverage"
     },
     "devDependencies": {
-        "@types/node": "^12.6.8",
-        "tslint": "^5.18.0",
-        "typescript": "^3.5.3",
-        "vsce": "^1.66.0",
-        "vscode": "^1.1.35"
+        "@types/jest": "^26.0.10",
+        "@types/node": "^14.6.0",
+        "@types/vscode": "^1.48.0",
+        "jest": "^26.4.1",
+        "ts-jest": "^26.2.0",
+        "tslint": "^6.1.3",
+        "typescript": "^3.9.7",
+        "vscode-test": "^1.4.0"
     },
     "license": "MIT",
     "homepage": "https://github.com/jongrant/vscode-csharpsortusings",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "watch": "node_modules/.bin/tsc -w -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
         "package": "node_modules/.bin/vsce package",
         "test": "jest",
         "coverage": "jest --coverage"
@@ -79,6 +80,7 @@
         "ts-jest": "^26.2.0",
         "tslint": "^6.1.3",
         "typescript": "^3.9.7",
+        "vscode": "^1.1.37",
         "vscode-test": "^1.4.0"
     },
     "license": "MIT",

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -35,14 +35,14 @@ const getNamespaceOrder = (ns: string, orderedNames: string[]): number => {
 
 export const process = (content: string, options: IFormatConfig): string => {
     try {
-        const trimSemiColon = /^\s+|;\s*$/;
+        const trimSemiColon = /;$/;
         content = replaceCode(content, /(\s*using\s+[.\w]+;)+/gm, rawBlock => {
             const items = rawBlock.split('\n').filter((l) => l && l.trim().length > 0);
             items.sort((a: string, b: string) => {
                 let res = 0;
                 // because we keep lines with indentation and semicolons.
-                a = a.replace(trimSemiColon, '');
-                b = b.replace(trimSemiColon, '');
+                a = a.trim().replace(trimSemiColon, '');
+                b = b.trim().replace(trimSemiColon, '');
                 if (options.sortUsingsOrder) {
                     const ns = options.sortUsingsOrder.split(' ');
                     res -= getNamespaceOrder(a.substr(6), ns);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,7 +8,7 @@ const getFormatOptions = (): formatting.IFormatConfig => {
 
     return {
         sortUsingsEnabled: cfg.get<boolean>('sort.usings.enabled', true),
-        sortUsingsOrder: cfg.get<string>('sort.usings.order', 'System'),
+        sortUsingsOrder: cfg.get<string>('sort.usings.order', 'System Microsoft'),
         sortUsingsSplitGroups: cfg.get<boolean>('sort.usings.splitGroups', true)
     };
 };

--- a/tests/sortOrder.test.ts
+++ b/tests/sortOrder.test.ts
@@ -1,0 +1,23 @@
+import { EOL } from 'os';
+import * as formatting  from '../src/formatting';
+
+const getFormatOptions = (): formatting.IFormatConfig => {
+    return {
+        sortUsingsEnabled: true,
+        sortUsingsOrder: 'System',
+        sortUsingsSplitGroups: true
+    };
+};
+
+describe('Sorting', function(){
+    it('Sorts short strings first', function() {
+        const testInput =
+            'using System.Text;' + EOL +
+            'using System;' + EOL;
+        const expected =
+            'using System;' + EOL +
+            'using System.Text;' + EOL;
+        const actual = formatting.process(testInput, getFormatOptions());
+        expect(actual.replace(/(\r\n|\n|\r)/gm, "").trim()).toBe(expected.replace(/(\r\n|\n|\r)/gm, "").trim());
+    })
+});

--- a/tests/sortOrder.test.ts
+++ b/tests/sortOrder.test.ts
@@ -20,4 +20,15 @@ describe('Sorting', function(){
         const actual = formatting.process(testInput, getFormatOptions());
         expect(actual.replace(/(\r\n|\n|\r)/gm, "").trim()).toBe(expected.replace(/(\r\n|\n|\r)/gm, "").trim());
     })
+
+    it('Sorts short strings first - even when the line starts with whitespace', function() {
+        const testInput =
+            ' using System.Text;' + EOL +
+            ' using System;' + EOL;
+        const expected =
+            ' using System;' + EOL +
+            ' using System.Text;' + EOL;
+        const actual = formatting.process(testInput, getFormatOptions());
+        expect(actual.replace(/(\r\n|\n|\r)/gm, "").trim()).toBe(expected.replace(/(\r\n|\n|\r)/gm, "").trim());
+    })
 });


### PR DESCRIPTION
I haven't had a chance to actually fix it, but these tests show that the sort order is wrong when the usings are indented. It puts "using System;" at the end of the system usings if the usings start with any whitespace. 

I'll probably update this with a fix shortly.